### PR TITLE
Reduced the drop-shadow on 'single-hadith-view' navigation buttons

### DIFF
--- a/public/css/all.css
+++ b/public/css/all.css
@@ -1372,13 +1372,13 @@ textarea {
     background: #f9f7f2;
     color: #75a7a8;
     border-radius: 5px;
-    box-shadow: 0 1px 24px -7px rgba(0,0,0,.15), 0 15px 24px rgba(0,0,0,.16);
+    box-shadow:	0 21px 28px -21px rgba(0,0,0,.09), 0 22px 29px rgba(0,0,0,.02);
     transition: .3s all ease;
     line-height: 1.3;
 }
 
 .button:hover {
-	box-shadow: 0 11px 8px -11px rgba(0,0,0,.15), 0 22px 19px rgba(0,0,0,.16);
+	box-shadow: 0 21px 28px -21px rgba(0,0,0,.09), 0 22px 29px rgba(0,0,0,0.052);
 }
 
 .button[disabled] {


### PR DESCRIPTION
Reduced the drop-shadow on 'single-hadith-view' navigation buttons 

Now consistent with the 'actualHadithContainer' css class and the overall flat-design of the page.