### PR TITLE
Added Hadith link in book view; Canonical links in Riyadussalihin

### DIFF
--- a/application/modules/front/controllers/CollectionController.php
+++ b/application/modules/front/controllers/CollectionController.php
@@ -238,7 +238,7 @@ class CollectionController extends SController
 				$viewVars['previousPermalink'] = $this->util->getPermalinkByURN($previousURN, "english");
 
 			// Add canonical links to single pages only
-			if ( $permalinkCanonical && count($pairs) === 1)
+			if ( $permalinkCanonical && $this->view->params['_pageType'] == "hadith" && count($pairs) === 1 )
 				$this->view->registerLinkTag(['rel' => 'canonical', 'href' => "https://sunnah.com" . ($permalinkCanonical)]);
 		}
 		

--- a/application/modules/front/controllers/CollectionController.php
+++ b/application/modules/front/controllers/CollectionController.php
@@ -236,6 +236,10 @@ class CollectionController extends SController
 			
 			if (isset($previousURN) && !is_null($previousURN))
 				$viewVars['previousPermalink'] = $this->util->getPermalinkByURN($previousURN, "english");
+
+			// Add canonical links to single pages only
+			if ( $permalinkCanonical && count($pairs) === 1)
+				$this->view->registerLinkTag(['rel' => 'canonical', 'href' => "https://sunnah.com" . ($permalinkCanonical)]);
 		}
 		
 		return $this->render('dispbook', $viewVars);
@@ -462,6 +466,9 @@ class CollectionController extends SController
 
 			if (isset($previousURN) && !is_null($previousURN))
 				$viewVars['previousPermalink'] = $this->util->getPermalinkByURN($previousURN, "english");
+
+			if ( $permalinkCanonical )
+				$this->view->registerLinkTag(['rel' => 'canonical', 'href' => "https://sunnah.com" . ($permalinkCanonical)]);
 		}
 
         return $this->render('dispbook', $viewVars);

--- a/application/modules/front/controllers/CollectionController.php
+++ b/application/modules/front/controllers/CollectionController.php
@@ -224,7 +224,22 @@ class CollectionController extends SController
 			$this->pathCrumbs($this->_book->englishBookName, "/".$collectionName."/".$lastlink);
 		}
         $this->pathCrumbs($this->_collection->englishTitle, "/$collectionName");
-        return $this->render('dispbook', $viewVars);  
+
+		// TODO: Expand to all verified collections at the end of the experiment
+		if ($this->_book->status > 3 && $collectionName == "riyadussalihin") {
+			$urn = $this->_entries[1][$pairs[0][1]]->arabicURN;
+			$permalinkCanonical = $this->util->getPermalinkByURN($urn);
+			$viewVars['permalinkCanonical'] = $permalinkCanonical;
+
+			if (isset($nextURN) && !is_null($nextURN))
+				$viewVars['nextPermalink'] = $this->util->getPermalinkByURN($nextURN, "english");
+			
+			if (isset($previousURN) && !is_null($previousURN))
+				$viewVars['previousPermalink'] = $this->util->getPermalinkByURN($previousURN, "english");
+		}
+		
+		return $this->render('dispbook', $viewVars);
+
 	}
 
 	public function actionTce() {
@@ -434,7 +449,21 @@ class CollectionController extends SController
         if (strlen($this->_book->englishBookName) > 0) {
             $this->pathCrumbs($this->_book->englishBookName." - <span class=arabic_text>".$this->_book->arabicBookName.'</span>', "/".$this->_collectionName."/".$this->_book->ourBookID);
         }
-        $this->pathCrumbs($this->_collection->englishTitle, "/$this->_collectionName");
+		$this->pathCrumbs($this->_collection->englishTitle, "/$this->_collectionName");
+		
+		// TODO: Expand to all verified collections at the end of the experiment
+		if ($this->_book->status > 3 && $this->_collectionName == "riyadussalihin") {
+			$urn = $arabicHadith->arabicURN;
+			$permalinkCanonical = $this->util->getPermalinkByURN($urn);
+			$viewVars['permalinkCanonical'] = $permalinkCanonical;
+
+			if (isset($nextURN) && !is_null($nextURN))
+				$viewVars['nextPermalink'] = $this->util->getPermalinkByURN($nextURN, "english");
+
+			if (isset($previousURN) && !is_null($previousURN))
+				$viewVars['previousPermalink'] = $this->util->getPermalinkByURN($previousURN, "english");
+		}
+
         return $this->render('dispbook', $viewVars);
 	}
 }

--- a/application/modules/front/models/Util.php
+++ b/application/modules/front/models/Util.php
@@ -323,6 +323,30 @@ class Util extends Model {
         return $permalink;
     }
 
+    public function getPermalinkByURN($urn, $language="arabic") {
+        // As of now, this method only works for hadith in verified books. 
+        // TODO: Extend to other books
+        if ($language !== "arabic") {
+            $hadithTranslation = $this->getHadith($urn, $language);
+            $urn = $hadithTranslation->matchingArabicURN;
+            
+            if ($urn === null) return null;
+        }
+
+        $hadith = $this->getHadith($urn, "arabic");
+        $collectionName = $hadith->collection;
+        $collection = $this->getCollection($collectionName);
+        
+        $book = $this->getBook($hadith->collection, $hadith->bookID, "english");
+        if ($book->status < 4) return null;
+        
+        // In case an entry lists multiple hadith numbers, use the first one
+        $hadithNumber = explode(",", $hadith->hadithNumber)[0];
+
+        $permalink = "/$collectionName:$hadithNumber";        
+        return $permalink;
+    }
+
     public function getCarouselHTML($arabicURNs) {
         $aURNs = $arabicURNs;
 		shuffle($aURNs);

--- a/application/modules/front/views/collection/hadith_reference.php
+++ b/application/modules/front/views/collection/hadith_reference.php
@@ -1,4 +1,7 @@
 <?php
+			use app\modules\front\models\Util;
+			$util = new Util();
+
 			$collection = $values[7];
 			$ourHadithNumber = $values[6];
 			$ourBookID = $values[8];
@@ -11,6 +14,8 @@
 			$hideReportError = $values[15];
 			$divname = $values[16];
 			$hideShare = $values[17] ?? false;
+			// TODO: Expand to all verified collections at the end of the experiment
+			$url = ($collection === "riyadussalihin") ? $util->getPermalinkByURN($values[0], "english") : null;
 
 			echo "<div class=bottomItems>\n";
 	    if (strlen($englishGrade1) > 0 or strlen($arabicGrade1) > 0) {
@@ -75,7 +80,10 @@
 			if ($bookstatus == 4) {
 				echo "<tr><td><b>Reference</b></td>";
 				echo "<td>&nbsp;:&nbsp;";
-				echo "$collectionEnglishTitle ".$values[5]."";
+				if ( $url !== null && $this->params["_pageType"] !== "hadith" )
+					echo "<a href=\"$url\">$collectionEnglishTitle ".$values[5]."</a>";
+				else
+					echo "$collectionEnglishTitle ".$values[5]."";
 				echo "</b></td></tr>";
 
 				if (strcmp($collectionHasBooks, "yes") == 0) {
@@ -112,6 +120,8 @@
 					elseif ($ourBookID == -1) $permalink = "/$collection/introduction/$ourHadithNumber";
 				}
 				else $permalink = "/$collection/$ourHadithNumber"; // This collection has no books.
+
+				if ( $url !== null ) $permalink = $url;
 			}
 			else {
 

--- a/public/css/all.css
+++ b/public/css/all.css
@@ -1161,7 +1161,9 @@ textarea {
 .hadith_permalink a:hover {
     text-decoration: underline;
 }
-
+.hadith_reference a {
+    color: #037d7d;
+}
 .hadith_reference {
     font-size: 11px;
     text-decoration: none;


### PR DESCRIPTION
The following hadith numbers occur twice in Riyadussalihin, the second one in most cases is a typo. Please fix those before pulling the changes. Otherwise the Next/Previous buttons won't work and we will be canonizing the wrong hadith.

Duplicate hadith numbers:
414
581
681
855
933
1043
1642