### PR TITLE
Hotfixes for Copy-Hadith-to-Clipboard feature

### DIFF
--- a/public/js/sunnah.js
+++ b/public/js/sunnah.js
@@ -269,7 +269,7 @@
 		if (itemsToCopy.arabic) {
 			var $arabicContainer = $hadithContainer.find('.arabic_hadith_full');
 			if ($arabicContainer.length) {
-				arabic = cleanText($arabicContainer.text());
+				arabic = cleanText(preserveNewLines($arabicContainer));
 			}
 		}
 
@@ -291,7 +291,7 @@
 
 			$englishGrade = $hadithContainer.find('.english_grade:nth-child(2)');
 			if ($englishGrade.length) {
-				englishGrade = cleanText($englishGrade.text()).slice(2);
+				englishGrade = cleanText($englishGrade.text());
 				if (englishGrade)
 					grade = englishGrade;
 			}
@@ -338,7 +338,7 @@
 
 			if ($chap.length) {
 				var chapEn	= $chap.find('.englishchapter').text(),
-					chapNo	= $chap.find('.achapno').text();
+					chapNo	= $chap.find('.echapno').text();
 
 				if (chapEn) {
 					chapEn = cleanText(chapEn);
@@ -371,7 +371,9 @@
 				if (bookNo || bookEn) {
 					if (chapNo || chapEn)
 						ref += ", ";
-					
+					else
+						ref += "\n";
+
 					ref += "Book";
 					ref += bookNo ? " " + bookNo : "";
 					ref += bookEn ? ": " + bookEn : "";
@@ -399,7 +401,7 @@
 		hadithStr += !grade		?	"" :  '\n' + 'Grade: ' + grade;
 		hadithStr += !hadithUrl	?	"" :  '\n' + hadithUrl;
 
-		return hadithStr;
+		return hadithStr.trim();
 	}
 
 
@@ -407,12 +409,23 @@
 		text = text
 			.replace(/<br *\/?>/g, '\n\n')
 			.replace(/(\S)( *)(\r\n|\r|\n){1}( *)(\S)/g, '$1 $5') // convert single newline to space
-			.replace(/( *)(\r\n|\r|\n){2,}( *)/g, '\n') // make >2 \n to a single \n
+			.replace(/( *)(\r\n|\r|\n){2,}( *)/g, '\n') // make >=2 \n to a single \n
 			.replace(/( *: *)/g, ': ') // Fix colon spacing
 			.replace(/( |\u00a0)+/g, ' ') // Convert multiple spaces or &nbsp; chars into a single space
 			.trim();
 
 		return text;
+	}
+
+
+	/**
+	 * Converting <br> element to newline character so that we don't lose paragraph information
+	 */
+	function preserveNewLines($obj) {
+		var temp = 	$obj.html()
+						.trim()
+						.replace(/<br *\/?>/g, '\n\n');
+		return $.parseHTML("<div>" + temp + "</div>")[0].innerText;
 	}
 
 


### PR DESCRIPTION
- Fixed the two missing letters in Grade
- Fixed chapter number (wasn't showing correctly in one book—was showing 1.00 as it was taking the Arabic chapter number)
- Separated complete reference information into separate lines (was showing in one line in non-standard books)
- Removed newline characters at the ends of copy-string
- Preserved newlines in Arabic text (which was coded as `<br>` element, that was being lost when we used jQuery `text()` function). This newline is important to preserve paragraphs in Arabic text. Especially useful for separating footnotes, references from main body of Arabic text. Otherwise, complete Arabic text is merged together into a single line. To see the importance of this operation, see these pages: https://sunnah.com/hisn#C24.00 , https://sunnah.com/urn/2107260
- Tested fixed code on all books