### PR TITLE
Removing Copy Button on Search Results page

### DIFF
--- a/application/components/search/SearchEngine.php
+++ b/application/components/search/SearchEngine.php
@@ -36,7 +36,7 @@ abstract class SearchEngine
         $resultset = $this->doSearchInternal();
         if ($resultset === null) {
             $this->doNotifyOutage();
-        } else {
+        } else if (YII_ENV != 'dev') {
             $this->logQuery($resultset->getCount());
         }
         return $resultset;

--- a/application/modules/front/views/collection/hadith_reference.php
+++ b/application/modules/front/views/collection/hadith_reference.php
@@ -149,9 +149,8 @@
 				//echo "<a href=\"javascript:permalink('$permalink');\">Permalink</a>";
 				//echo "<a href=\"$permalink\">Permalink</a>";
 			if (!isset($hideReportError) or !$hideReportError) echo "<span class=reportlink href=\"javascript: void(0);\" onclick=\"reportHadith(".$urn.", '".$divName."')\">Report Error</span> | ";
-			if (!$hideShare) echo  "<span class=sharelink onclick=\"share('$permalink')\">Share</span> | "; 
-				echo "<span class=copylink title=\"Copy hadith to clipboard\">Copy</span> "; 
-				echo "<span class=copycbcaret title=\"Change copy options\">▼</span>".
-			"</div>". 
-		"</div>";
+			if (!$hideShare) echo "<span class=sharelink onclick=\"share('$permalink')\">Share</span> | "; 
+			if (!$hideShare) echo "<span class=copylink title=\"Copy hadith to clipboard\">Copy</span> "; 
+			if (!$hideShare) echo "<span class=copycbcaret title=\"Change copy options\">▼</span>";
+			echo "</div></div>";
 ?>

--- a/public/js/sunnah.js
+++ b/public/js/sunnah.js
@@ -547,29 +547,29 @@
 	$("#cb_flyout").on("click", function(e) { e.stopPropagation() });
 
 	$(".copycbcaret").on("click", function(e) {
-		var offset = $(e.currentTarget).offset(),
-			settings = getCbSettings(),
-			$cbFlyout = jQuery("#cb_flyout");
+		var $cbFlyout = jQuery("#cb_flyout");
+		if ($cbFlyout.is(':hidden')) {
+			var offset 	 = $(e.currentTarget).offset(),
+			settings = getCbSettings();
 
-		for (option in settings) {
-			$cbFlyout.find("[type=checkbox][name="+option+"]").prop("checked", settings[option])
-			$cbFlyout.find("[type=radio][value="+settings[option]+"]").prop("checked", true)
+			for (option in settings) {
+				$cbFlyout.find("[type=checkbox][name="+option+"]").prop("checked", settings[option])
+				$cbFlyout.find("[type=radio][value="+settings[option]+"]").prop("checked", true)
+			}
+
+			$("#cb_flyout")
+				.css("top", offset.top)
+				.css("left", offset.left)
+				.show(400);
+		
+			// Avoid immediate trigger
+			setTimeout( function() {
+				$("body").one("click.flyout", function(e) {
+					$("#cb_flyout").hide(400)
+				});
+			}, 500);
 		}
-
-		$("#cb_flyout")
-			.css("top", offset.top)
-			.css("left", offset.left)
-			.show(400);
-	
-		// Avoid immediate trigger
-		setTimeout( function() {
-			$("body").one("click.flyout", function(e) {
-				$("#cb_flyout").hide(400)
-			});
-		}, 500);
 	});
-
-
   });
 
     var langLoaded = new Object();


### PR DESCRIPTION
1. Resolution of issue #88 by removing copy button from Search Results page.
2. Fixing development environment error
3. When we pressed copy button caret to close copy menu, and then pressed it again to open it, then the menu opened and then closed automatically. This issue was fixed.