### PR TITLE
Fix 1 CRITICAL issue - updated CURL 7.79.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3.1-apache
+FROM php:7.3-apache
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM php:7.3-apache
+FROM php:7.3.1-apache
 
 WORKDIR /app
 
-RUN apt-get update
-RUN apt-get install -y git zip unzip
+RUN apt-get update && apt remove curl libc-bin -y
+RUN apt-get install -y git zip unzip wget
+RUN wget https://curl.haxx.se/download/curl-7.79.0.zip && unzip curl-7.79.0.zip && rm -R /usr/local/include/curl
+RUN cd curl-7.79.0 && ./configure --with-wolfssl && make install
 RUN docker-php-ext-install pdo pdo_mysql mysqli
 RUN a2enmod rewrite
 


### PR DESCRIPTION
## What
Updated CURL version to 7.79.0 from 7.74.0

## Why
Updated due to container security issue.
CVE issue number : CVE-2021-22945 [Link](https://nvd.nist.gov/vuln/detail/CVE-2021-22945)

