### PR TITLE
Bug fix: remove search on not existing arabic index for elastic

### DIFF
--- a/application/components/search/engines/KeywordSearchEngine.php
+++ b/application/components/search/engines/KeywordSearchEngine.php
@@ -35,15 +35,6 @@ class KeywordSearchEngine extends SearchEngine
         }
         $suggestions = $resultset->getSuggestions();
 
-
-        // TODO: This code is deprecated, arabic and english hadith share an index in elastic. This should never be reached
-        if ($resultset->getCount() === 0) {
-            // If no English results were found, do Arabic search
-            $engine = new ArabicKeywordSearchEngine();
-            $engine->setLimitPage($this->limit, $this->page);
-            $resultset = $engine->doSearch($this->query);
-        }
-
         if ($resultset !== null) {
             // Only English engine supports suggestions
             $resultset->setSuggestions($suggestions);


### PR DESCRIPTION
We now use a unified index. This call causes us to return an error message when there are no records instead of our standard response