### PR TITLE
Searchbar Bug: Webkit Overflow

### DIFF
--- a/public/css/all.css
+++ b/public/css/all.css
@@ -238,6 +238,8 @@ textarea {
 
 
 #header {
+	display: flex;
+	flex-direction: column;
 	width: 100%;
 	background: var(--header-bg);
 	background-repeat: repeat;


### PR DESCRIPTION
Fixed an issue where due to Webkit's handling of CSS, the search bar would overflow on iOS.
![WhatsApp Image 2025-03-31 at 15 33 08_66f42c24](https://github.com/user-attachments/assets/6b34bec8-715f-43bc-a996-dac3d9bb3f47)
