### PR TITLE
Fix: Share/Copy popup background in dark mode

### DIFF
--- a/public/css/themes/dark.css
+++ b/public/css/themes/dark.css
@@ -30,3 +30,23 @@
     --sticky-color: #19524d;
     --link-color: #56D0D0;
 }
+
+[data-theme="dark"] #cb_flyout {
+    background-image: none;
+    background-color: var(--sidePanel_bg);
+    border-color: #444;
+    box-shadow: 0 4px 8px #111;
+    color: var(--primary-text-color);
+}
+
+[data-theme="dark"] #cb_flyout legend {
+    color: var(--primary-text-color);
+}
+
+[data-theme="dark"] #cb_flyout label {
+    color: var(--primary-text-color);
+}
+
+[data-theme="dark"] #cb_flyout input {
+    accent-color: var(--link-color);
+}


### PR DESCRIPTION
### Description
This PR fixes an issue where the "Share/Copy" settings popup (`#cb_flyout`) remained in light mode even when the global website theme was set to dark mode. 
### Changes
- Added dark mode overrides in [public/css/themes/dark.css](cci:7://file:///c:/Users/abdul/OneDrive/Desktop/sunnah/public/css/themes/dark.css:0:0-0:0) for the `#cb_flyout` element.
- Set `background-image: none` to remove the default light-textured background.
- Used CSS variables (`--sidePanel_bg`, `--primary-text-color`, etc.) to ensure the popup matches the existing dark theme colors.
- Added `accent-color` to checkboxes and radio buttons for better visibility in dark mode.
