### PR TITLE
Bump Dockerfile base image to php:8.4-apache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-apache
+FROM php:8.4-apache
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Bumps the `Dockerfile` base image from `php:7.3-apache` to `php:8.4-apache` so
that `docker compose up --build` actually completes on `master`.

## Why

The current base image installs PHP 7.3, but:

- `composer.json` requires `"php": ">=8.3.0"`
- `composer.lock` pins `symfony/var-dumper v8.0.8` and `symfony/yaml v8.0.10`,
  both of which require PHP `>= 8.4`
- `yiisoft/yii2 2.0.54` requires PHP `>= 7.4.0`

So `composer install` aborts inside the container on a fresh clone of
`master`, taking down the documented "Quick start" path with it.

Full context and reproducer in #165.

## Verification

Verified locally that the one-line change makes the build complete
end-to-end:

- `composer install` finished in 28.5s with all 57 packages installed
- The image exported successfully
- No other Dockerfile changes were needed — the `pdo`, `pdo_mysql`, and
  `mysqli` PHP extensions and Apache's `rewrite` module install the same
  way on the new base

## Risks

PHP 8.x is a substantial jump from 7.3, but:

- The `composer.json` already declares `php >= 8.3.0`, so the application
  is expected to run on PHP 8.x regardless of the Dockerfile.
- Recent commit history includes "More PHP 8 migration changes" and related
  fixes, suggesting the codebase is already PHP 8.x-aware.
- This change only affects the dev/Docker build path; production deployment
  is configured separately.

If you'd prefer a different target version (e.g. `php:8.3-apache`), happy to
update — `8.4` is the smallest version that satisfies every constraint in
`composer.lock` without touching dependencies.

Fixes #165
