### PR TITLE
Remove obsolete version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: mysql:5.7.22


### PR DESCRIPTION
## Summary

Removes the top-level `version: '3'` key from `docker-compose.yml`. The field
is no longer used by Compose V2 and triggers an "obsolete" warning on every
`docker compose` invocation:

```
the attribute `version` is obsolete, it will be ignored, please remove it
to avoid potential confusion
```

The rest of the file is already valid Compose Spec syntax (`services:`,
`build:`, `image:`, `volumes:`, etc.), so no other changes are needed.

## Verification

Ran `docker compose config` against the patched file — it still parses
correctly, expands both services as before, and no longer emits the
deprecation warning.

## Note

Independent of #166 (PHP version bump). They can land in either order; both
target the local Docker development path.
