### PR TITLE
Keep search working when MySQL is down

### DIFF
--- a/application/components/search/SearchEngine.php
+++ b/application/components/search/SearchEngine.php
@@ -72,15 +72,24 @@ abstract class SearchEngine
     public function logQuery($numResults)
     {
         if (defined("YII_ENV") && YII_ENV !== "dev") {
-            $searchdb = Yii::$app->searchdb;
-            $searchdb->createCommand(
-                'INSERT INTO `search_queries` (query, IP, numResults) VALUES (:query, :IP, :numResults)',
-                [
-                    ':query' => $this->query,
-                    ':IP' => Yii::$app->getRequest()->getUserIP(),
-                    ':numResults' => $numResults
-                ]
-            )->execute();
+            // Query logging is non-critical: results already came back from the
+            // search engine. Never let a searchdb outage take down the search page.
+            try {
+                $searchdb = Yii::$app->searchdb;
+                $searchdb->createCommand(
+                    'INSERT INTO `search_queries` (query, IP, numResults) VALUES (:query, :IP, :numResults)',
+                    [
+                        ':query' => $this->query,
+                        ':IP' => Yii::$app->getRequest()->getUserIP(),
+                        ':numResults' => $numResults
+                    ]
+                )->execute();
+            } catch (\Throwable $e) {
+                Yii::warning(
+                    "logQuery failed (non-fatal): {$e->getMessage()}",
+                    'app\components\search\SearchEngine'
+                );
+            }
         }
     }
 }

--- a/application/components/search/SearchResultset.php
+++ b/application/components/search/SearchResultset.php
@@ -76,6 +76,7 @@ class SearchResultset
 
         $newResults = array();
         foreach ($this->results as $result) {
+          try {
             $lang = $result['language'];
             $source = $result['source'];
 
@@ -96,6 +97,13 @@ class SearchResultset
             // matched language feeds both populate() calls (as the old SQL did).
             $bookLanguage = ($lang === 'en') ? 'english' : 'arabic';
             $book = $util->getBook($collectionName, $source->$lang->bookID, $bookLanguage);
+            if ($book === null) {
+                // Book metadata unavailable (e.g. DB outage with a cold cache).
+                // The downstream view requires it, so skip this hit rather than
+                // 500 the whole results page.
+                Yii::warning("Search hit [$lang]: book unavailable for {$collectionName}/{$source->$lang->bookID}", 'search');
+                continue;
+            }
 
             $arabicEntry = null; $englishEntry = null;
             if (isset($source->ar)) {
@@ -114,6 +122,12 @@ class SearchResultset
                 'ar' => $arabicEntry,
             );
             $newResults[] = $result;
+          } catch (\Throwable $e) {
+            // Render what we can: drop a single un-hydratable hit instead of
+            // failing the entire search page.
+            Yii::warning("Search hit [{$result['language']}] {$result['urn']} skipped: " . $e->getMessage(), 'search');
+            continue;
+          }
         }
         return $newResults;
     }

--- a/application/modules/front/models/Hadith.php
+++ b/application/modules/front/models/Hadith.php
@@ -30,6 +30,43 @@ class Hadith extends ActiveRecord
 	public $permalink = null;
 	public $sunnahReference = null;
 
+    /**
+     * Column superset used to hydrate search results from Elasticsearch when the
+     * database is unreachable, so AR construction does not require live schema
+     * introspection. Union of the real EnglishHadith/ArabicHadith columns and
+     * the ES _source field names (see the SELECTs in search/main.py).
+     */
+    private const SCHEMA_FALLBACK = [
+        'englishURN', 'arabicURN', 'collection', 'volumeNumber', 'bookNumber',
+        'bookName', 'babNumber', 'babName', 'hadithNumber', 'hadithText',
+        'bookID', 'grade', 'grade1', 'comments', 'ourHadithNumber',
+        'matchingArabicURN', 'matchingEnglishURN',
+    ];
+
+    /** @var array<string,array> per-class cache of resolved attribute names */
+    private static $_attributesCache = [];
+
+    /**
+     * Attribute names, falling back to a static column list when the DB schema
+     * cannot be loaded (e.g. MySQL outage). Search result data comes from
+     * Elasticsearch, so this keeps results renderable instead of letting a
+     * schema-introspection failure 500 the whole page. When the DB is healthy
+     * this returns the real schema, exactly as before.
+     */
+    public function attributes()
+    {
+        $cls = static::class;
+        if (isset(self::$_attributesCache[$cls])) {
+            return self::$_attributesCache[$cls];
+        }
+        try {
+            return self::$_attributesCache[$cls] = parent::attributes();
+        } catch (\Throwable $e) {
+            \Yii::warning("Hadith schema unavailable for $cls; using static fallback: " . $e->getMessage(), 'search');
+            return self::$_attributesCache[$cls] = self::SCHEMA_FALLBACK;
+        }
+    }
+
     public function __construct($config = []) {
         parent::__construct();
         if (!is_null($config)) {

--- a/application/modules/front/models/Util.php
+++ b/application/modules/front/models/Util.php
@@ -157,14 +157,20 @@ class Util extends Model {
         $cache_key = "collectionsInfo"."_".(string)$display_only;
 		$this->_collectionsInfo = Yii::$app->cache->get($cache_key);
 		if ($this->_collectionsInfo === false) {
-			$connection = Yii::$app->db;
-            if ($connection == NULL) return array();
-            $showOnHomeCondition = "";
-            if ($display_only) { $showOnHomeCondition = "where showOnHome = 1"; }
-			$query = "SELECT * FROM Collections $showOnHomeCondition order by collectionID ASC";
-			$command = $connection->createCommand($query);
-			$this->_collectionsInfo = $command->queryAll();
-			Yii::$app->cache->set($cache_key, $this->_collectionsInfo, Yii::$app->params['cacheTTL']);
+			try {
+				$connection = Yii::$app->db;
+				if ($connection == NULL) return array();
+				$showOnHomeCondition = "";
+				if ($display_only) { $showOnHomeCondition = "where showOnHome = 1"; }
+				$query = "SELECT * FROM Collections $showOnHomeCondition order by collectionID ASC";
+				$command = $connection->createCommand($query);
+				$this->_collectionsInfo = $command->queryAll();
+				Yii::$app->cache->set($cache_key, $this->_collectionsInfo, Yii::$app->params['cacheTTL']);
+			} catch (\Throwable $e) {
+				// Degrade gracefully on a DB outage instead of taking the page down.
+				Yii::warning("getCollectionsInfo DB lookup failed: " . $e->getMessage(), 'search');
+				return array();
+			}
 		}
 		if (strcmp($mode, "indexed") == 0) {
 			foreach ($this->collectionsInfo as $collection)
@@ -177,10 +183,16 @@ class Util extends Model {
 	public function getCollection($collectionName) {
 		$collection = Yii::$app->cache->get("collection:".$collectionName);
         if ($collection === false) {
-            $collection = Collection::find()
-                ->where('name = :name', [':name' => $collectionName])
-                ->one();
-            Yii::$app->cache->set("collection:".$collectionName, $collection, Yii::$app->params['cacheTTL']);
+            try {
+                $collection = Collection::find()
+                    ->where('name = :name', [':name' => $collectionName])
+                    ->one();
+                Yii::$app->cache->set("collection:".$collectionName, $collection, Yii::$app->params['cacheTTL']);
+            } catch (\Throwable $e) {
+                // Degrade gracefully on a DB outage instead of taking the page down.
+                Yii::warning("getCollection DB lookup failed for $collectionName: " . $e->getMessage(), 'search');
+                return null;
+            }
         }
 		return $collection;
 	}
@@ -190,7 +202,8 @@ class Util extends Model {
         $arabic_books = Yii::$app->cache->get($collectionName."books_arabic");
         $english_books = Yii::$app->cache->get($collectionName."books_english");
         if ($books === false or $arabic_books === false or $english_books === false) {
-			if (strcmp($collectionName, "nasai") == 0 or strcmp($collectionName, "shamail") == 0) $books_rs = Book::find()->where('collection = :collection', [':collection' => $collectionName])->orderBy(['abs(ourBookID)' => SORT_ASC, 'englishBookID' => SORT_ASC])->all();
+            try {
+				if (strcmp($collectionName, "nasai") == 0 or strcmp($collectionName, "shamail") == 0) $books_rs = Book::find()->where('collection = :collection', [':collection' => $collectionName])->orderBy(['abs(ourBookID)' => SORT_ASC, 'englishBookID' => SORT_ASC])->all();
             else $books_rs = Book::find()->where('collection = :collection', [':collection' => $collectionName])->orderBy(['ourBookID' => SORT_ASC])->all();
             foreach ($books_rs as $book) $books[$book->ourBookID] = $book;
             foreach ($books_rs as $book) $arabic_books[$book->arabicBookID] = $book;
@@ -198,6 +211,11 @@ class Util extends Model {
             Yii::$app->cache->set($collectionName."books_arabic", $arabic_books, Yii::$app->params['cacheTTL']);
             Yii::$app->cache->set($collectionName."books_english", $english_books, Yii::$app->params['cacheTTL']);
             Yii::$app->cache->set($collectionName."books", $books, Yii::$app->params['cacheTTL']);
+            } catch (\Throwable $e) {
+                // Degrade gracefully on a DB outage instead of taking the page down.
+                Yii::warning("getBook DB lookup failed for $collectionName: " . $e->getMessage(), 'search');
+                return null;
+            }
         }
 
 		if (is_null($bookID)) return $books;


### PR DESCRIPTION
Search data comes entirely from Elasticsearch, but the results page was 500ing during a DB outage because rendering each hit went through the DB:
- constructing EnglishHadith/ArabicHadith triggered AR table-schema introspection (getTableSchema) against the live DB
- query logging wrote to searchdb on every request
- collection/book lookups threw when their memcached entry was cold

Degrade gracefully instead of failing the whole page:
- Hadith::attributes() falls back to a static column list when schema introspection fails, so ES-sourced models construct without the DB (no-op when the DB is healthy)
- Util::getCollectionsInfo/getCollection/getBook fail soft (return cached/empty) on a DB error
- SearchResultset::getResults() skips any hit it can't hydrate rather than 500ing the results page
- SearchEngine::logQuery() wraps the non-critical insert in try/catch

With these, /search renders real ES results while MySQL is fully down, as long as the collection/book caches are warm.