### PR TITLE
Fix mobile layout for long hadith grade text (#65)

### DIFF
--- a/application/modules/front/views/collection/hadith_reference.php
+++ b/application/modules/front/views/collection/hadith_reference.php
@@ -37,7 +37,7 @@
 			    ($arabicExists && strlen($arabicGrade1) > 0)) and
 			   (strcmp($collection->name, "adab") != 0)) {
     	    echo "<div class=hadith_annotation>";
-            echo "<table class=gradetable cellspacing=0 cellpadding=0 border=0>";
+            echo "<div class=\"gradetable\">";
             $grade_detail_panels = array();
 
             // This should really happen in the controllers/models
@@ -64,43 +64,45 @@
             $num_grades = max(count($english_grades), count($arabic_grades));
 			$firstGradePrinted = false;
             for ($i = 0; $i < $num_grades; $i++) {
-                echo "<tr>";
+                echo "<div class=\"grade_row\">";
                 if (array_key_exists($i, $english_grades)) {
                     $grade = $english_grades[$i]['grade'];
                     $graded_by = $english_grades[$i]['graded_by'];
                     $grade_detail = $english_grades[$i]['grade_detail'] ?? '';
-                    echo "<td class=\"english_grade grade_label\" width=\"64px\">";
+                    echo "<div class=\"grade_col english_grade_col\">";
+                    echo "<span class=\"english_grade grade_label\">";
 					if (!$firstGradePrinted) echo "<b>Grade</b>:";
-					echo "</td>";
-                    echo "<td class=english_grade width=\"36%\">&nbsp;<b>".$grade."</b>";
+					echo "</span>";
+                    echo "<span class=\"english_grade grade_value\">&nbsp;<b>".$grade."</b>";
                     if (strlen(trim($graded_by)) > 0) echo " (".$graded_by.")";
                     renderGradeDetail($grade_detail, $grade_detail_panels);
-                    echo "</td>";
+                    echo "</span>";
+                    echo "</div>";
                 } else {
-                    echo "<td height=100% class=english_grade></td>";
-                    echo "<td height=100% class=english_grade></td>";
+                    echo "<div class=\"grade_col english_grade_col\"></div>";
                 }
 
                 if (array_key_exists($i, $arabic_grades)) {
                     $grade = $arabic_grades[$i]['grade'];
                     $graded_by = $arabic_grades[$i]['graded_by'];
                     $grade_detail = $arabic_grades[$i]['grade_detail'] ?? '';
-    				echo "<td class=\"arabic_grade arabic\">&nbsp;<b> ".$grade."</b>";
+                    echo "<div class=\"grade_col arabic_grade_col\">";
+    				echo "<span class=\"arabic_grade arabic grade_value\">&nbsp;<b> ".$grade."</b>";
 	    			if (strlen(trim($graded_by)) > 0) echo "&nbsp;&nbsp; (".$graded_by.") ";
                     renderGradeDetail($grade_detail, $grade_detail_panels, 'arabic');
-                    echo "</td>";
-					echo "<td class=\"arabic_grade arabic grade_label\" width=\"64px\">";
+                    echo "</span>";
+					echo "<span class=\"arabic_grade arabic grade_label\">";
 					if (!$firstGradePrinted) echo "<b>حكم</b>&nbsp;&nbsp;&nbsp;:";
-					echo "</td>";
+					echo "</span>";
+                    echo "</div>";
                 } else {
-                    echo "<td height=100% width=60% class=arabic_grade></td>";
-                    echo "<td height=100% width=60% class=arabic_grade></td>";
+                    echo "<div class=\"grade_col arabic_grade_col\"></div>";
                 }
 
-                echo "</tr>";
+                echo "</div>";
 				$firstGradePrinted = true;
             }
-            echo "</table>";
+            echo "</div>";
             if (count($grade_detail_panels) > 0) {
                 echo "<div class=\"grade_detail_panels\">";
                 foreach ($grade_detail_panels as $grade_detail_panel) {

--- a/public/css/all.css
+++ b/public/css/all.css
@@ -1491,7 +1491,7 @@ input.searchquery{
 	padding-left: 10px;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 768px) {
 	.grade_row {
 		flex-direction: column;
 	}
@@ -1499,10 +1499,6 @@ input.searchquery{
 	.grade_col {
 		flex: 1 1 100%;
 		width: 100%;
-	}
-
-	.arabic_grade_col {
-		justify-content: flex-start;
 	}
 }
 
@@ -1523,7 +1519,7 @@ input.searchquery{
 }
 
 .gradetable .grade_label {
-    flex: 0 0 auto;
+    flex: 0 0 64px;
     white-space: nowrap;
     overflow-wrap: normal;
 }

--- a/public/css/all.css
+++ b/public/css/all.css
@@ -1462,31 +1462,75 @@ input.searchquery{
 .gradetable {
 	width: 100%;
 	padding: 0 25px 0 15px;
-	table-layout: fixed;
+	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+}
+
+.grade_row {
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+}
+
+.grade_col {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	flex: 1 1 50%;
+	min-width: 0;
 	box-sizing: border-box;
 }
 
+.english_grade_col {
+	padding-right: 10px;
+}
+
+.arabic_grade_col {
+	justify-content: flex-end;
+	padding-left: 10px;
+}
+
+@media (max-width: 480px) {
+	.grade_row {
+		flex-direction: column;
+	}
+
+	.grade_col {
+		flex: 1 1 100%;
+		width: 100%;
+	}
+
+	.arabic_grade_col {
+		justify-content: flex-start;
+	}
+}
+
 .english_grade {
-    vertical-align: top;
     font-size: 14px;
     font-family: Verdana;
     padding-top: 10px;
     text-align: left;
-	height: 100%;
     overflow-wrap: anywhere;
+    min-width: 0;
 }
 
 .arabic_grade {
-    vertical-align: top;
     direction: rtl;
     text-align: right;
     overflow-wrap: anywhere;
+    min-width: 0;
 }
 
 .gradetable .grade_label {
-    width: 64px;
+    flex: 0 0 auto;
     white-space: nowrap;
     overflow-wrap: normal;
+}
+
+.gradetable .grade_value {
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .grade_detail_toggle {

--- a/public/css/hadith.css
+++ b/public/css/hadith.css
@@ -216,7 +216,7 @@
 	padding-left: 10px;
 }
 
-@media (max-width: 480px) {
+@media (max-width: 768px) {
 	.grade_row {
 		flex-direction: column;
 	}
@@ -224,10 +224,6 @@
 	.grade_col {
 		flex: 1 1 100%;
 		width: 100%;
-	}
-
-	.arabic_grade_col {
-		justify-content: flex-start;
 	}
 }
 
@@ -259,7 +255,7 @@ a.action_toTop:hover span   { background-position: -11px 0; }
 }
 
 .gradetable .grade_label {
-	flex: 0 0 auto;
+	flex: 0 0 64px;
 	white-space: nowrap;
 	overflow-wrap: normal;
 }

--- a/public/css/hadith.css
+++ b/public/css/hadith.css
@@ -187,8 +187,48 @@
 
 .gradetable {
 	width: 100%;
-	table-layout: fixed;
 	box-sizing: border-box;
+	display: flex;
+	flex-direction: column;
+}
+
+.grade_row {
+	display: flex;
+	flex-wrap: wrap;
+	width: 100%;
+}
+
+.grade_col {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	flex: 1 1 50%;
+	min-width: 0;
+	box-sizing: border-box;
+}
+
+.english_grade_col {
+	padding-right: 10px;
+}
+
+.arabic_grade_col {
+	justify-content: flex-end;
+	padding-left: 10px;
+}
+
+@media (max-width: 480px) {
+	.grade_row {
+		flex-direction: column;
+	}
+
+	.grade_col {
+		flex: 1 1 100%;
+		width: 100%;
+	}
+
+	.arabic_grade_col {
+		justify-content: flex-start;
+	}
 }
 
 .top_link a span {
@@ -203,25 +243,30 @@ a.action_toTop span     { background-position: -11px 0; }
 a.action_toTop:hover span   { background-position: -11px 0; }
 
 .english_grade {
-	vertical-align: top;
-	font-size: 14px; 
-	font-family: Verdana; 
+	font-size: 14px;
+	font-family: Verdana;
 	padding-top: 10px;
 	text-align: left;
 	overflow-wrap: anywhere;
+	min-width: 0;
 }
 
 .arabic_grade {
-	vertical-align: top; 
-	direction: rtl; 
+	direction: rtl;
 	text-align: right;
 	overflow-wrap: anywhere;
+	min-width: 0;
 }
 
 .gradetable .grade_label {
-	width: 64px;
+	flex: 0 0 auto;
 	white-space: nowrap;
 	overflow-wrap: normal;
+}
+
+.gradetable .grade_value {
+	min-width: 0;
+	overflow-wrap: anywhere;
 }
 
 .grade_detail_toggle {


### PR DESCRIPTION
Fixes #65

## Problem
The hadith grade section (`.gradetable`) was rendered as an HTML `<table>` with a fixed 4-column layout: a narrow label column (`Grade:`), an English grade value column, an Arabic grade value column, and a narrow Arabic label column (`حكم:`). On small/mobile viewports these four rigid columns get squeezed side by side, so when a grade string is more than a couple of words (e.g. a longer scholar attribution or compound grading), the text has no room to lay out properly.

## Verification of the 2020 premise
Confirmed the underlying markup is still a `<table class=gradetable>` today (`application/modules/front/views/collection/hadith_reference.php`), so the original "change from table to flexbox" suggestion still applies. A separate template used for the clipboard/plain-text reference view (`hadith_reference_tce.php`) does not use this grade table and was left untouched. However, this grade block is also rendered via `collection/hadith_reference.php` on `collection/tce.php` (TCE page), `dispbook.php`, and `search/index.php` — those three surfaces are affected by this change too and are included in the manual test plan below.

## Fix
- Replaced the `<table>/<tr>/<td>` grade markup with a `div`-based structure (`.gradetable` > `.grade_row` > `.grade_col` > label/value `span`s), preserving the same DOM sibling order/classes so existing "copy to clipboard" JS selectors (`sunnah.js`, which uses `:nth-child`/`:first` on `.english_grade`/`.arabic_grade`) keep working unchanged.
- Updated `.gradetable` and related rules in `public/css/hadith.css` and `public/css/all.css` to use `display: flex` instead of `table-layout: fixed`, so each grade row's English/Arabic columns can flex and wrap based on content instead of being locked to fixed pixel/percentage widths.
- Added a `max-width: 768px` breakpoint (matching the site's existing responsive breakpoint) that stacks each grade row's English and Arabic columns vertically (full width) instead of forcing them side by side, giving long grade text the full row width to wrap on small and tablet screens.
- `.gradetable .grade_label` keeps a fixed `flex: 0 0 64px` basis (not `flex: 0 0 auto`) so that multi-grade hadiths — where only the first grade row prints the "Grade:"/"حكم:" label text and rows 2+ emit an empty label span — still line up their value columns consistently across all rows, matching the old `table-layout: fixed` behavior.
- Scoped changes only to the grade table styling/markup — no other page/component layout touched.

## Test plan
- [ ] Manually verify a hadith page with a short one-word grade (e.g. "Sahih") still renders as before on desktop and mobile.
- [ ] Manually verify a hadith page with a long/multi-word grade string wraps within its column and stacks full-width on a narrow viewport instead of overflowing/squeezing.
- [ ] Manually verify a hadith with a multi-grade `grade1` JSON array (2+ entries) keeps its English/Arabic value columns aligned across rows.
- [ ] Verify "Copy to clipboard" grade text still copies correctly (English and Arabic-only cases).
- [ ] Spot-check the grade block on `collection/tce.php`, `dispbook.php`, and `search/index.php`, not just the single-hadith page.