### PR TITLE
Fix hadith reference URLs with letter suffix (#104)

### DIFF
--- a/application/modules/front/models/Util.php
+++ b/application/modules/front/models/Util.php
@@ -96,7 +96,23 @@ class Util extends Model {
             return null;
         }
 
-        // If the hadith is not found and the collection is Muslim, 
+        // If the hadith is not found and the number has a trailing letter suffix
+        // (e.g. "4290b"), the stored hadithNumber may have a space before the
+        // suffix (e.g. "4290 b"). Retry the lookup with the suffix separated out.
+        preg_match('/^(\d+)\s*([a-zA-Z]+)$/', $hadithNumber, $suffixMatches);
+        if (count($suffixMatches) === 3) {
+            $spacedNum = $suffixMatches[1]." ".$suffixMatches[2];
+            $direct = $this->searchByNumber($collectionName, $spacedNum);
+            if (!is_null($direct)) {
+                foreach ($direct as $result) {
+                    $book = $this->getBook($collectionName, $result['bookID'], "arabic");
+                    if ($book->status >= 4) return $result['arabicURN'];
+                }
+                return null;
+            }
+        }
+
+        // If the hadith is not found and the collection is Muslim,
         // rewrite the hadith number to search for
         if ($collectionName === 'muslim') {
 			// Did the user supply a letter?


### PR DESCRIPTION
Refs #104

## Summary

Hadith reference URLs with a letter suffix (e.g. `sunnah.com/abudawud:4290b`) returned a 404, even though the hadith exists and is displayed on its book page (e.g. `sunnah.com/abudawud/38`).

## Root cause

`Util::getURNByNumber()` looks up a hadith by exact match against the `hadithNumber` column. For letter-suffixed hadith numbers, the stored value has a space before the suffix (e.g. `"4290 b"`), while permalinks and user-typed URLs use the space-free form (`"4290b"`, see the `preg_replace("/(\d)\s*([a-zA-Z])/", "$1$2", ...)` normalization already used when generating `permalink`/`canonicalReference` in `ArabicHadith.php`). The direct lookup in `Util::getURNByNumber()` never re-tried with a space inserted, so it fell straight through to "not found" for any collection other than Muslim, which already had its own special-cased space-insertion logic.

## Fix

Added a general retry step in `Util::getURNByNumber()`: when the direct match fails and the requested hadith number matches `digits + letters` (e.g. `4290b`), retry the lookup with the letters separated by a space (`4290 b`) before falling through to the multiply-numbered-hadith case. This applies to all collections, not just Muslim, and doesn't change the existing Muslim-specific handling (letter-detection retry and the "no letter supplied -> try adding 'a'" heuristic), which remains in place as-is.

## Out of scope

This PR deliberately does **not** implement the second request in the issue (a new short-URL scheme for Muwatta Malik, e.g. `sunnah.com/malik:445`). That is a separate feature request and is left for a follow-up PR.

## Test plan

- [x] Traced the fix against the exact URL from the issue: `abudawud:4290b` now finds the row stored as `hadithNumber = "4290 b"` via the new suffix-retry step and resolves through `getURNByNumber` -> `front/collection/urn` the same way a normal numeric lookup does.
- No existing automated test suite covers this lookup path (none found under the repo for `Util`/hadith-number resolution), so no test file was changed.

