### PR TITLE
Fix window repaint on JS scroll events - move to CSS (#63)

### DIFF
--- a/public/css/all.css
+++ b/public/css/all.css
@@ -364,6 +364,34 @@ textarea {
 	display: none;
 }
 
+/*
+ * Sticky-header state, driven by an IntersectionObserver toggling this
+ * class on #site (see sunnah.js) instead of a scroll listener writing
+ * inline styles on every scroll tick. See issue #63.
+ */
+#site.header-stuck #header {
+	position: fixed;
+	top: 0;
+}
+
+#site.header-stuck #topspace {
+	display: block;
+}
+
+#site.header-stuck #toolbar {
+	display: none;
+}
+
+#site.header-stuck #search {
+	bottom: 31px; /* crumbs height + 12 bottom padding */
+}
+
+#site.header-stuck #sidePanel {
+	position: fixed;
+	top: 65px;
+	left: var(--sidePanel-left, auto);
+}
+
 .sidePanelContainer {
 	width: 15%; 
 	float: left;

--- a/public/js/sunnah.js
+++ b/public/js/sunnah.js
@@ -457,31 +457,47 @@
 	}
 
 
-   $(document).ready(function () {  
+   $(document).ready(function () {
 
-	$(window).scroll(function() {
-		if ($(window).scrollTop() > 750) $("#back-to-top").addClass('bttenabled');
-		else $("#back-to-top").removeClass('bttenabled');
+	// Back-to-top button: toggle only when the 750px threshold is actually
+	// crossed, not on every scroll tick.
+	var pastBackToTop = false;
+	window.addEventListener('scroll', function() {
+		var shouldShow = window.scrollY > 750;
+		if (shouldShow !== pastBackToTop) {
+			pastBackToTop = shouldShow;
+			$("#back-to-top").toggleClass('bttenabled', shouldShow);
+		}
+	}, { passive: true });
 
-		if ($(window).scrollTop() > 25) { // this number is height of short banner + breadcrumbs - 40
-			$("#banner").removeClass('bannerTop');
-			$("#banner").addClass('bannerMiddle');
-			$("#header").css('position', 'fixed');
-			$("#header").css('top', '0');
-			$("#topspace").css('display', 'block');
-			$("#toolbar").css('display', 'none');
-			$("#search").css('bottom', '31px'); // crumbs height + 12 bottom padding
-			$("#sidePanel").css({'position': 'fixed', 'top': '65px', 'left': $(".mainContainer").position().left - $("#sidePanel").width() - 55}); // last number is sidePanelContainer padding
-		}
-		else {
-			$("#banner").removeClass('bannerMiddle');
-			$("#banner").addClass('bannerTop');
-			$("#header").css('position', 'relative');
-			$("#topspace").css('display', 'none');
-			$("#toolbar").css('display', 'block');
-			$("#search").css('bottom', '45px'); // crumbs height + 20 bottom padding
-			$("#sidePanel").css('position', 'static');
-		}
+	// Sticky/compact header: previously a $(window).scroll() handler wrote
+	// several inline styles (position, top, display, bottom) and read
+	// $(".mainContainer").position() on every single scroll event, forcing
+	// a synchronous layout + repaint of the whole page on every scroll tick.
+	// Replaced with an IntersectionObserver, which only fires when the
+	// sentinel actually crosses the viewport edge, and CSS classes
+	// (.header-stuck in all.css) instead of per-tick inline style writes.
+	function updateSidePanelOffset() {
+		var left = $(".mainContainer").position().left - $("#sidePanel").width() - 55; // last number is sidePanelContainer padding
+		document.getElementById('site').style.setProperty('--sidePanel-left', left + 'px');
+	}
+
+	var $site = $("#site");
+	var headerObserver = new IntersectionObserver(function(entries) {
+		var entry = entries[0];
+		var stuck = !entry.isIntersecting;
+		$("#banner").toggleClass('bannerMiddle', stuck).toggleClass('bannerTop', !stuck);
+		if (stuck) updateSidePanelOffset();
+		$site.toggleClass('header-stuck', stuck);
+	}, { threshold: 0 });
+
+	// #toolbar sits at the very top of #header; once it scrolls out of
+	// view the header has passed the same ~25px threshold the old code
+	// checked for via window.scrollTop().
+	headerObserver.observe(document.getElementById('toolbar'));
+
+	$(window).on('resize', function() {
+		if ($site.hasClass('header-stuck')) updateSidePanelOffset();
 	});
 
 	$("body").append('<div id="sharefuzz"></div>');


### PR DESCRIPTION
Fixes #63

## Problem
The sticky/compact-header effect (shrinking the banner, hiding the toolbar, fixing the header to the top, and repositioning the side panel) was driven by a `$(window).scroll()` jQuery handler that ran on **every** scroll event. On each tick it:
- wrote several inline styles (`position`, `top`, `display`, `bottom`) unconditionally, even when the state hadn't changed, and
- called `$(".mainContainer").position()`, which forces a synchronous layout read.

That combination produces a forced synchronous layout + full repaint on every scroll pixel, which is exactly what the attached Chrome DevTools Performance profile in the issue shows: a Long Task dominated by `Painting`/`Rendering` time while scrolling `sunnah.com/riyadussalihin/18`.

Verified the same `$(window).scroll(...)` handler (`public/js/sunnah.js`, previously lines 462-485) is still present, unchanged, in current `master`.

## Fix
- Replaced the scroll listener with an `IntersectionObserver` on `#toolbar`, which only fires when the header actually crosses the same ~25px threshold the old code polled for on every tick — not on every scroll event.
- Moved the visual states (fixed header, hidden toolbar, shrunk banner, repositioned search box/side panel) into a single `.header-stuck` CSS class (`public/css/all.css`) instead of ad-hoc inline style writes.
- The side panel's dynamic `left` offset (previously recomputed via a layout-forcing `.position()` call on every scroll event) is now computed once per state transition and on resize, via a CSS custom property (`--sidePanel-left`).
- Kept the back-to-top button toggle but guarded it so it only touches the class when the 750px threshold is actually crossed, instead of every scroll tick.

No visual behavior change intended — same thresholds, same classes/styles, same effect — only removed the per-scroll-tick DOM writes and forced layout reads.

## Test plan
- [x] `node --check public/js/sunnah.js` passes (syntax valid)
- [ ] Manual/visual verification on a running instance (no local dev environment available in this sandbox — please verify header/side-panel/back-to-top behavior on a hadith page like `/riyadussalihin/18` before merging)
